### PR TITLE
Using personal access token for PRs and merge done by GitHub actions

### DIFF
--- a/.github/workflows/android_pr.yml
+++ b/.github/workflows/android_pr.yml
@@ -64,9 +64,9 @@ jobs:
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PAT_GITHUB}}
       - name: Approve Dependabot PRs
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PAT_GITHUB}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1
         with:
-          reviewers: kevalpatel2106
           labels: Change type > dependencies
+          repo-token: ${{ secrets.PAT_GITHUB }}


### PR DESCRIPTION
## Overview :notebook:

<!-- A brief description of what this PR does and what's its purpose. -->

## Problem with opening and merging PRs using GitHub Actions:
By default, if the `token` input in any step which triggers workflow (e.g. opening PR or merging PR) is left empty or if you set it to `GITHUB_TOKEN`, Pull Requests created by the Update Gradle Wrapper action do not trigger any other workflow. So, for example, if you have any `on: pull_request` or `on: push` workflow that runs CI checks on Pull Requests, they won't normally be triggered.

This is a restriction imposed by GitHub Actions to avoid accidentally creating recursive workflow runs ([read more](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token)).

### Here is what you can do to trigger additional 

Use a [Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token): create a PAT with the `repo` scope and add it [as a secret](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) into your repository. Then configure the `token` input to use such encrypted secret. 

> Note that the Pull Request author will be set to the GitHub user that the PAT belongs to: as Pull Request author, this user cannot be assigned as reviewer and cannot approve it.


## What this PR does?

So this PR, adds my (@kevalpatel2106's) personal token to the actions secrets and uses this to open and merge PRs using GitHub Actions.